### PR TITLE
Use Services global variable if possible

### DIFF
--- a/dist/chrome/api/findnow/implementation.js
+++ b/dist/chrome/api/findnow/implementation.js
@@ -22,7 +22,9 @@
 
 'use strict';
 
-var {Services} = ChromeUtils.import('resource://gre/modules/Services.jsm');
+var Services = globalThis.Services || ChromeUtils.import(
+  'resource://gre/modules/Services.jsm'
+).Services;
 var {ExtensionSupport} = ChromeUtils.import('resource:///modules/ExtensionSupport.jsm');
 
 /**

--- a/dist/chrome/content/exporter.js
+++ b/dist/chrome/content/exporter.js
@@ -22,7 +22,9 @@
 
 'use strict';
 
-const {Services} = ChromeUtils.import('resource://gre/modules/Services.jsm');
+const Services = globalThis.Services || ChromeUtils.import(
+  'resource://gre/modules/Services.jsm'
+).Services;
 
 /**
  * DEBUG enable/disable

--- a/dist/chrome/content/overlay.js
+++ b/dist/chrome/content/overlay.js
@@ -22,7 +22,9 @@
 
 "use strict";
 
-const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 /**
  * DEBUG enable/disable

--- a/dist/chrome/content/utils.js
+++ b/dist/chrome/content/utils.js
@@ -22,7 +22,9 @@
 
 'use strict';
 
-const {Services} = ChromeUtils.import('resource://gre/modules/Services.jsm');
+const Services = globalThis.Services || ChromeUtils.import(
+  'resource://gre/modules/Services.jsm'
+).Services;
 const {OS} = ChromeUtils.import('resource://gre/modules/osfile.jsm');
 const {MailUtils} = ChromeUtils.import("resource:///modules/MailUtils.jsm");
 const {MailServices} = ChromeUtils.import("resource:///modules/MailServices.jsm");


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and also available in all system globals from version 104 https://bugzilla.mozilla.org/show_bug.cgi?id=1667455 , and those code doesn't have to import Services.jsm for recent versions.